### PR TITLE
3 - Move contributing instructions to contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,30 @@
+## Contributing to the Plugin
+
+Plugin source code is hosted on [GitHub](https://github.com/jenkinsci/gitlab-plugin).
+New feature proposals and bug fix proposals should be submitted as
+[GitHub pull requests](https://help.github.com/articles/creating-a-pull-request).
+Fork the repository on GitHub, prepare your change on your forked
+copy, and submit a pull request (see [here](https://github.com/jenkinsci/gitlab-plugin/pulls) for open pull requests). Your pull request will be evaluated by the [plugin's CI job](https://ci.jenkins.io/blue/organizations/jenkins/Plugins%2Fgitlab-plugin/).
+
+If you are adding new features please make sure that they support Jenkins Pipeline jobs.
+See [here](https://github.com/jenkinsci/workflow-plugin/blob/master/COMPATIBILITY.md) for some information.
+
+
+Before submitting your change make sure that:
+* your changes work with the oldest and latest supported GitLab version
+* new features are provided with tests
+* refactored code is provided with regression tests
+* the code formatting follows the plugin standard
+* imports are organised
+* you updated the help docs
+* you updated the README
+* you have used spotbugs to see if you haven't introduced any new warnings
+
+## Testing With Docker
+
+See https://github.com/jenkinsci/gitlab-plugin/tree/master/src/docker/README.md
+
+## Release Workflow
+
+To perform a full plugin release, maintainers can run ``mvn release:prepare release:perform`` To release a snapshot, e.g. with a bug fix for users to test, just run ``mvn deploy``
+

--- a/README.md
+++ b/README.md
@@ -563,41 +563,14 @@ This saves time in projects where builds can stay long time in a build queue and
 
 Version 1.2.1 of the plugin introduces a backwards-incompatible change
 for Pipeline jobs. They will need to be manually reconfigured when you
-upgrade to this version. Freestyle jobs are not impacted. Please see the
-README for details.
-
+upgrade to this version. Freestyle jobs are not impacted.
 
 ## Contributing to the Plugin
 
-Plugin source code is hosted on [GitHub](https://github.com/jenkinsci/gitlab-plugin).
-New feature proposals and bug fix proposals should be submitted as
-[GitHub pull requests](https://help.github.com/articles/creating-a-pull-request).
-Fork the repository on GitHub, prepare your change on your forked
-copy, and submit a pull request (see [here](https://github.com/jenkinsci/gitlab-plugin/pulls) for open pull requests). Your pull request will be evaluated by the [plugin's CI job](https://ci.jenkins.io/blue/organizations/jenkins/Plugins%2Fgitlab-plugin/).
-
-If you are adding new features please make sure that they support Jenkins Pipeline jobs.
-See [here](https://github.com/jenkinsci/workflow-plugin/blob/master/COMPATIBILITY.md) for some information.
-
-
-Before submitting your change make sure that:
-* your changes work with the oldest and latest supported GitLab version
-* new features are provided with tests
-* refactored code is provided with regression tests
-* the code formatting follows the plugin standard
-* imports are organised
-* you updated the help docs
-* you updated the README
-* you have used findbugs to see if you haven't introduced any new warnings
-
-## Testing With Docker
-
-See https://github.com/jenkinsci/gitlab-plugin/tree/master/src/docker/README.md 🙂
-
-## Release Workflow
-
-To perform a full plugin release, maintainers can run ``mvn release:prepare release:perform`` To release a snapshot, e.g. with a bug fix for users to test, just run ``mvn deploy``
+Detailed instructions for code and documentation contributions to the plugin are available in the [contributing guide](CONTRIBUTING.md).
 
 ## Changelog
+
 For recent versions, see [GitHub Releases](https://github.com/jenkinsci/gitlab-plugin/releases).
 
-For versions 1.5.14 and older, see [CHANGELOG.md](CHANGELOG.md).
+For versions 1.5.21 and older, see the [historical changelog](https://github.com/jenkinsci/gitlab-plugin/blob/gitlab-plugin-1.5.34/CHANGELOG.md).


### PR DESCRIPTION
##  Move contributing instructions to contributing guide

Keep the README focused on end users.

Submission checklist:

* [x] your changes work with the oldest and latest supported GitLab version
* [x] the code formatting follows the plugin standard
* [x] imports are organised
* [x] you updated the help docs
* [x] you updated the README
* [x] you have used spotbugs to confirm you haven't introduced any new warnings
* ~~new features are provided with tests~~
* ~~refactored code is provided with regression tests~~
